### PR TITLE
Update metadata public-keys read

### DIFF
--- a/files/condor-boot.sh
+++ b/files/condor-boot.sh
@@ -7,7 +7,7 @@ MD_PUBLIC_KEYS=$(echo $METADATA | jq '."public-keys"')
 
 ssh_keys(){
     if [[ $(echo $MD_PUBLIC_KEYS | jq '.|length') -gt 0 ]]; then
-        echo $MD_PUBLIC_KEYS | jq -r '.' >> /root/.ssh/authorized_keys
+        echo $MD_PUBLIC_KEYS | jq -r '.[]' > /root/.ssh/authorized_keys
     else
         echo "No SSH Public keys to add."
     fi


### PR DESCRIPTION
Vultr Metadata public-keys have been updated to an array from a string, this fixes adding ssh keys on boot. 